### PR TITLE
fix(roles/k8s-controller-manager): Change `/healthz` to `/livez` for service checking

### DIFF
--- a/roles/k8s-controller-manager/tasks/install.yml
+++ b/roles/k8s-controller-manager/tasks/install.yml
@@ -99,8 +99,8 @@
   ansible.builtin.pause:
     seconds: 5
 
-- name: Ensuring that the service is running GET - /healthz
+- name: Ensuring that the service is running GET - /livez
   ansible.builtin.uri:
-    url: "http://{{ ansible_host }}:10252/healthz"
+    url: "http://{{ ansible_host }}:10252/livez"
   tags:
     - test


### PR DESCRIPTION
https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health