### PR TITLE
fix(k8s-scheduler): `healthz` is being deprecated since v1.16

### DIFF
--- a/roles/k8s-scheduler/tasks/install.yml
+++ b/roles/k8s-scheduler/tasks/install.yml
@@ -86,8 +86,8 @@
   ansible.builtin.pause:
     seconds: 5
 
-- name: Ensuring that kube-scheduler is running /healthz
+- name: Ensuring that kube-scheduler is running /livez
   ansible.builtin.uri:
-    url: "http://{{ ansible_host }}:10251/healthz"
+    url: "http://{{ ansible_host }}:10251/livez"
   tags:
     - test


### PR DESCRIPTION
Rely on `/livez` endpoint